### PR TITLE
2.8.0

### DIFF
--- a/src/Benchmarks/Http/Benchmark.Json/Benchmark.Json.csproj
+++ b/src/Benchmarks/Http/Benchmark.Json/Benchmark.Json.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Benchmarks/Http/Benchmark.PlainText/Benchmark.PlainText.csproj
+++ b/src/Benchmarks/Http/Benchmark.PlainText/Benchmark.PlainText.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Benchmarks/Mvc/Benchmark.Mvc.Json/Benchmark.Mvc.Json.csproj
+++ b/src/Benchmarks/Mvc/Benchmark.Mvc.Json/Benchmark.Mvc.Json.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Benchmarks/Mvc/Benchmark.Mvc.PlainText/Benchmark.Mvc.PlainText.csproj
+++ b/src/Benchmarks/Mvc/Benchmark.Mvc.PlainText/Benchmark.Mvc.PlainText.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Samples/Playground/Playground.csproj
+++ b/src/Samples/Playground/Playground.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Samples/Playground/Program.cs
+++ b/src/Samples/Playground/Program.cs
@@ -7,83 +7,25 @@ using Twino.Mvc.Controllers;
 using Twino.Mvc.Controllers.Parameters;
 using Twino.Mvc.Filters.Route;
 using Twino.Protocols.TMQ;
+using Twino.Protocols.WebSocket;
 using Twino.Server;
 
 namespace Playground
 {
-    public class Login
-    {
-        public string User { get; set; }
-        public string Pass { get; set; }
-    }
-
-    public class User
-    {
-        public string Name { get; set; }
-        public string Lastname { get; set; }
-    }
-
-    [Route("x")]
-    public class BController : TwinoController
-    {
-        [HttpGet("c/{?x}")]
-        public async Task<IActionResult> C(string x)
-        {
-            return await StringAsync("Xhello: " + x);
-        }
-
-        [HttpGet("")]
-        public async Task<IActionResult> B()
-        {
-            return await StringAsync("Xhello");
-        }
-
-        [HttpGet("d")]
-        public async Task<IActionResult> D()
-        {
-            return await StringAsync("Xhello D");
-        }
-    }
-
-
-    [Route("")]
-    public class AController : TwinoController
-    {
-        [HttpGet("c/{?x}")]
-        public async Task<IActionResult> C(string x)
-        {
-            return await StringAsync("hello: " + x);
-        }
-
-        [HttpGet("")]
-        public async Task<IActionResult> B()
-        {
-            return await StringAsync("hello");
-        }
-
-        [HttpGet("d")]
-        public async Task<IActionResult> D()
-        {
-            return await StringAsync("hello D");
-        }
-
-        [HttpGet("e/{x}")]
-        public async Task<IActionResult> E(string x)
-        {
-            return await StringAsync("hello E: " + x);
-        }
-    }
-
     class Program
     {
         static void Main(string[] args)
         {
-            TwinoMvc mvc = new TwinoMvc();
-            mvc.Init();
-            TwinoServer server = new TwinoServer();
-            server.UseMvc(mvc);
-            server.Start(26222);
-            server.BlockWhileRunning();
+            TwinoServer _server = new TwinoServer();
+            _server = new TwinoServer(ServerOptions.CreateDefault());
+            _server.UseWebSockets(async (socket) => { await socket.SendAsync("Welcome"); },
+                                  async (socket, message) =>
+                                  {
+                                      Console.WriteLine("# " + message);
+                                      await socket.SendAsync(message);
+                                  });
+            _server.Start(46100);
+            _server.BlockWhileRunning();
         }
     }
 }

--- a/src/Samples/Sample.Connectors/Sample.Connectors.csproj
+++ b/src/Samples/Sample.Connectors/Sample.Connectors.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <Authors></Authors>
         <Company></Company>

--- a/src/Samples/Sample.Http.Server/Sample.Http.Server.csproj
+++ b/src/Samples/Sample.Http.Server/Sample.Http.Server.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>8</LangVersion>
     </PropertyGroup>
 

--- a/src/Samples/Sample.MQ.Data/Sample.MQ.Data.csproj
+++ b/src/Samples/Sample.MQ.Data/Sample.MQ.Data.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Samples/Sample.Mq/Sample.Mq.csproj
+++ b/src/Samples/Sample.Mq/Sample.Mq.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Samples/Sample.Mvc/Sample.Mvc.csproj
+++ b/src/Samples/Sample.Mvc/Sample.Mvc.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <LangVersion>8</LangVersion>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Samples/Sample.Tmq/Sample.Tmq.csproj
+++ b/src/Samples/Sample.Tmq/Sample.Tmq.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Samples/Sample.WebSocket.Client/Sample.WebSocket.Client.csproj
+++ b/src/Samples/Sample.WebSocket.Client/Sample.WebSocket.Client.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>8</LangVersion>
     </PropertyGroup>
 

--- a/src/Samples/Sample.WebSocket.Server/Sample.WebSocket.Server.csproj
+++ b/src/Samples/Sample.WebSocket.Server/Sample.WebSocket.Server.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>8</LangVersion>
     </PropertyGroup>
 

--- a/src/Tests/Test.Connector/AbsoluteConnectorTest.cs
+++ b/src/Tests/Test.Connector/AbsoluteConnectorTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using Twino.Client.WebSocket;
 using Twino.Client.WebSocket.Connectors;
@@ -17,7 +18,7 @@ namespace Test.Connector
         public AbsoluteConnectorTest()
         {
             _server = new TwinoServer(ServerOptions.CreateDefault());
-            _server.UseWebSockets(async (socket, data) => { await socket.SendAsync("Welcome"); },
+            _server.UseWebSockets(async (socket) => { await socket.SendAsync("Welcome"); },
                                   async (socket, message) =>
                                   {
                                       _receivedMessages++;
@@ -26,15 +27,15 @@ namespace Test.Connector
         }
 
         [Fact]
-        public void Connect()
+        public async Task Connect()
         {
             _server.Start(46431);
-            System.Threading.Thread.Sleep(250);
+            await Task.Delay(1250);
 
-            WsAbsoluteConnector connector = new WsAbsoluteConnector(TimeSpan.FromSeconds(1));
+            WsAbsoluteConnector connector = new WsAbsoluteConnector(TimeSpan.FromMilliseconds(500));
             connector.AddHost("ws://127.0.0.1:46431");
             connector.Run();
-            System.Threading.Thread.Sleep(1000);
+            await Task.Delay(1250);
 
             Assert.True(connector.IsConnected);
 

--- a/src/Tests/Test.Connector/Test.Connector.csproj
+++ b/src/Tests/Test.Connector/Test.Connector.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
 
         <IsPackable>false</IsPackable>
 

--- a/src/Tests/Test.Ioc/Test.Ioc.csproj
+++ b/src/Tests/Test.Ioc/Test.Ioc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Tests/Test.Mq/Test.Mq.csproj
+++ b/src/Tests/Test.Mq/Test.Mq.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Tests/Test.Mvc/Test.Mvc.csproj
+++ b/src/Tests/Test.Mvc/Test.Mvc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
 
         <IsPackable>false</IsPackable>
 

--- a/src/Tests/Test.SerializableModel/Test.SerializableModel.csproj
+++ b/src/Tests/Test.SerializableModel/Test.SerializableModel.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
 
         <IsPackable>false</IsPackable>
 

--- a/src/Twino.Client.Connectors/StickyConnector.cs
+++ b/src/Twino.Client.Connectors/StickyConnector.cs
@@ -41,6 +41,7 @@ namespace Twino.Client.Connectors
         public override void Run()
         {
             _running = true;
+            ConnectSafe();
 
             if (_timer != null)
                 return;
@@ -55,26 +56,32 @@ namespace Twino.Client.Connectors
                 }
 
                 if (NeedReconnect() && !_connecting)
-                {
-                    try
-                    {
-                        _connecting = true;
-                        Connect();
-                    }
-                    catch (Exception ex)
-                    {
-                        RaiseException(ex);
-                    }
-                    finally
-                    {
-                        _connecting = false;
-                    }
-                }
+                    ConnectSafe();
             }, Interval);
 
             _timer.Start(ThreadPriority.BelowNormal);
         }
 
+        /// <summary>
+        /// Connects without throwing exception, handles it and raises connector's exception event
+        /// </summary>
+        private void ConnectSafe()
+        {
+            try
+            {
+                _connecting = true;
+                Connect();
+            }
+            catch (Exception ex)
+            {
+                RaiseException(ex);
+            }
+            finally
+            {
+                _connecting = false;
+            }
+        }
+        
         /// <summary>
         /// Aborts the connector and disconnects from the server.
         /// </summary>

--- a/src/Twino.Client.Connectors/Twino.Client.Connectors.csproj
+++ b/src/Twino.Client.Connectors/Twino.Client.Connectors.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <Title>Twino.Client.Connectors</Title>
         <Product>Twino.Client.Connectors</Product>
         <Description>Connectors for twino WebSocket and TMQ protocols</Description>
         <PackageTags>twino,server,client,connector,websocket,tmq</PackageTags>
-        <AssemblyVersion>2.7.18</AssemblyVersion>
-        <FileVersion>2.7.18</FileVersion>
-        <PackageVersion>2.7.18</PackageVersion>
+        <AssemblyVersion>2.8.0</AssemblyVersion>
+        <FileVersion>2.8.0</FileVersion>
+        <PackageVersion>2.8.0</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.Client.TMQ/Twino.Client.TMQ.csproj
+++ b/src/Twino.Client.TMQ/Twino.Client.TMQ.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <Title>Twino.Client.TMQ</Title>
         <Product>Twino.Client.TMQ</Product>
         <Description>Twino Messaging Queue Client to connect all TMQ Servers</Description>
         <PackageTags>twino,tmq,client,mq,messaging,queue</PackageTags>
-        <AssemblyVersion>2.7.18</AssemblyVersion>
-        <FileVersion>2.7.18</FileVersion>
-        <PackageVersion>2.7.18</PackageVersion>
+        <AssemblyVersion>2.8.0</AssemblyVersion>
+        <FileVersion>2.8.0</FileVersion>
+        <PackageVersion>2.8.0</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.Client.WebSocket/Twino.Client.WebSocket.csproj
+++ b/src/Twino.Client.WebSocket/Twino.Client.WebSocket.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Title>Twino.Client.WebSocket</Title>
     <Product>Twino.Client.WebSocket</Product>
     <Description>Twino WebSocket Client to connect all WebSocket servers</Description>
     <PackageTags>twino,websocket,client</PackageTags>
-    <AssemblyVersion>2.7.18</AssemblyVersion>
-    <FileVersion>2.7.18</FileVersion>
-    <PackageVersion>2.7.18</PackageVersion>
+    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <FileVersion>2.8.0</FileVersion>
+    <PackageVersion>2.8.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
     <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.Core/ThreadTimer.cs
+++ b/src/Twino.Core/ThreadTimer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Twino.Core
 {
@@ -112,7 +113,9 @@ namespace Twino.Core
             {
                 _thread.Abort();
             }
-            catch { }
+            catch
+            {
+            }
 
             _thread = null;
         }

--- a/src/Twino.Core/Twino.Core.csproj
+++ b/src/Twino.Core/Twino.Core.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Title>Twino.Core</Title>
     <Product>Twino.Core</Product>
     <Description>Twino Core library for all twino servers, protocols and services</Description>
     <PackageTags>twino,server,core</PackageTags>
-    <AssemblyVersion>2.7.18</AssemblyVersion>
-    <FileVersion>2.7.18</FileVersion>
-    <PackageVersion>2.7.18</PackageVersion>
+    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <FileVersion>2.8.0</FileVersion>
+    <PackageVersion>2.8.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
     <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.Extensions.Data/Twino.Extensions.Data.csproj
+++ b/src/Twino.Extensions.Data/Twino.Extensions.Data.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Title>Twino.Extensions.Data</Title>
     <Product>Twino.Extensions.Data</Product>
     <Description>Entity Framework Core Data Context extension for Twino IOC</Description>
     <PackageTags>twino,entity,framework,data,context,factory,ioc,service</PackageTags>
-    <AssemblyVersion>2.7.18</AssemblyVersion>
-    <FileVersion>2.7.18</FileVersion>
-    <PackageVersion>2.7.18</PackageVersion>
+    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <FileVersion>2.8.0</FileVersion>
+    <PackageVersion>2.8.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
     <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.Extensions.Http/Twino.Extensions.Http.csproj
+++ b/src/Twino.Extensions.Http/Twino.Extensions.Http.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Title>Twino.Extensions.Http</Title>
     <Product>Twino.Extensions.Http</Product>
     <Description>HttpClient Factory extension for Twino IOC</Description>
     <PackageTags>twino,http,client,factory,ioc,dependency,injection,service</PackageTags>
-    <AssemblyVersion>2.7.18</AssemblyVersion>
-    <FileVersion>2.7.18</FileVersion>
-    <PackageVersion>2.7.18</PackageVersion>
+    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <FileVersion>2.8.0</FileVersion>
+    <PackageVersion>2.8.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
     <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.Ioc/Twino.Ioc.csproj
+++ b/src/Twino.Ioc/Twino.Ioc.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Title>Twino.Ioc</Title>
     <Product>Twino.Ioc</Product>
     <Description>Twino IOC Service containers and scopes</Description>
     <PackageTags>twino,ioc,dependency,injection,service,container,scope</PackageTags>
-    <AssemblyVersion>2.7.18</AssemblyVersion>
-    <FileVersion>2.7.18</FileVersion>
-    <PackageVersion>2.7.18</PackageVersion>
+    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <FileVersion>2.8.0</FileVersion>
+    <PackageVersion>2.8.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
     <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.MQ.Data/Twino.MQ.Data.csproj
+++ b/src/Twino.MQ.Data/Twino.MQ.Data.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Title>Twino.MQ.Data</Title>
     <Product>Twino.MQ.Data</Product>
     <Description>Persistant queue message data library for Twino MQ</Description>
     <PackageTags>twino,server,messaging,queue,mq,persistent,database,db</PackageTags>
-    <AssemblyVersion>2.7.18</AssemblyVersion>
-    <FileVersion>2.7.18</FileVersion>
-    <PackageVersion>2.7.18</PackageVersion>
+    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <FileVersion>2.8.0</FileVersion>
+    <PackageVersion>2.8.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
     <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.MQ/Twino.MQ.csproj
+++ b/src/Twino.MQ/Twino.MQ.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Title>Twino.MQ</Title>
     <Product>Twino.MQ</Product>
     <Description>Messaging Queue Server library with TMQ Protocol via Twino Server</Description>
     <PackageTags>twino,server,tmq,messaging,queue,mq</PackageTags>
-    <AssemblyVersion>2.7.18</AssemblyVersion>
-    <FileVersion>2.7.18</FileVersion>
-    <PackageVersion>2.7.18</PackageVersion>
+    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <FileVersion>2.8.0</FileVersion>
+    <PackageVersion>2.8.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
     <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.Mvc.Auth.Jwt/Twino.Mvc.Auth.Jwt.csproj
+++ b/src/Twino.Mvc.Auth.Jwt/Twino.Mvc.Auth.Jwt.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Title>Twino.Mvc.Auth.Jwt</Title>
     <Product>Twino.Mvc.Auth.Jwt</Product>
     <Description>JSON Web Token Authentication and Authorization library for Twino MVC</Description>
     <PackageTags>twino,http,mvc,jwt,token,authentication,authorization</PackageTags>
-    <AssemblyVersion>2.7.18</AssemblyVersion>
-    <FileVersion>2.7.18</FileVersion>
-    <PackageVersion>2.7.18</PackageVersion>
+    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <FileVersion>2.8.0</FileVersion>
+    <PackageVersion>2.8.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
     <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.Mvc/Twino.Mvc.csproj
+++ b/src/Twino.Mvc/Twino.Mvc.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Title>Twino.Mvc</Title>
     <Product>Twino.Mvc</Product>
     <Description>MVC Library for Twino Http Server</Description>
     <PackageTags>twino,http,server,mvc</PackageTags>
-    <AssemblyVersion>2.7.18</AssemblyVersion>
-    <FileVersion>2.7.18</FileVersion>
-    <PackageVersion>2.7.18</PackageVersion>
+    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <FileVersion>2.8.0</FileVersion>
+    <PackageVersion>2.8.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
     <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.Protocols.Http/HttpOptions.cs
+++ b/src/Twino.Protocols.Http/HttpOptions.cs
@@ -12,7 +12,7 @@ namespace Twino.Protocols.Http
         /// <summary>
         /// Maximum keeping alive duration for each TCP connection
         /// </summary>
-        public int HttpConnectionTimeMax { get; set; } = 300;
+        public int HttpConnectionTimeMax { get; set; } = 0;
 
         /// <summary>
         /// Maximum request lengths (includes content)

--- a/src/Twino.Protocols.Http/Twino.Protocols.Http.csproj
+++ b/src/Twino.Protocols.Http/Twino.Protocols.Http.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Title>Twino.Protocols.Http</Title>
     <Product>Twino.Protocols.Http</Product>
     <Description>Twino Http Protocol library and server extension for Twino Server</Description>
     <PackageTags>twino,tcp,server,http,protocol</PackageTags>
-    <AssemblyVersion>2.7.18</AssemblyVersion>
-    <FileVersion>2.7.18</FileVersion>
-    <PackageVersion>2.7.18</PackageVersion>
+    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <FileVersion>2.8.0</FileVersion>
+    <PackageVersion>2.8.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
     <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.Protocols.TMQ/Twino.Protocols.TMQ.csproj
+++ b/src/Twino.Protocols.TMQ/Twino.Protocols.TMQ.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Title>Twino.Protocols.TMQ</Title>
     <Product>Twino.Protocols.TMQ</Product>
     <Description>Twino Messaging Queue (TMQ) Protocol library and server extension for Twino Server</Description>
     <PackageTags>twino,tcp,server,http,messaging,queue,tmq,mq,protocol</PackageTags>
-    <AssemblyVersion>2.7.18</AssemblyVersion>
-    <FileVersion>2.7.18</FileVersion>
-    <PackageVersion>2.7.18</PackageVersion>
+    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <FileVersion>2.8.0</FileVersion>
+    <PackageVersion>2.8.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
     <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.Protocols.WebSocket/MethodWebSocketConnectionHandler.cs
+++ b/src/Twino.Protocols.WebSocket/MethodWebSocketConnectionHandler.cs
@@ -15,6 +15,11 @@ namespace Twino.Protocols.WebSocket
     public delegate Task WebSocketConnectedHandler(WsServerSocket socket, ConnectionData data);
 
     /// <summary>
+    /// Websocket handshake is completed and it's ready to send and receive messages
+    /// </summary>
+    public delegate Task WebSocketReadyHandler(WsServerSocket socket);
+
+    /// <summary>
     /// Twino WebSocket Server with WebSocketMessageRecievedHandler method implementation handler
     /// </summary>
     internal class MethodWebSocketConnectionHandler : IProtocolConnectionHandler<WsServerSocket, WebSocketMessage>
@@ -25,15 +30,17 @@ namespace Twino.Protocols.WebSocket
         private readonly WebSocketMessageRecievedHandler _messageHandler;
 
         private readonly WebSocketConnectedHandler _connectedHandler;
+        private readonly WebSocketReadyHandler _readyHandler;
 
         public MethodWebSocketConnectionHandler(WebSocketMessageRecievedHandler handler)
-            : this(null, handler)
+            : this(null, null, handler)
         {
         }
 
-        public MethodWebSocketConnectionHandler(WebSocketConnectedHandler connectedHandler, WebSocketMessageRecievedHandler messageHandler)
+        public MethodWebSocketConnectionHandler(WebSocketConnectedHandler connectedHandler, WebSocketReadyHandler readyHandler, WebSocketMessageRecievedHandler messageHandler)
         {
             _connectedHandler = connectedHandler;
+            _readyHandler = readyHandler;
             _messageHandler = messageHandler;
         }
 
@@ -55,7 +62,8 @@ namespace Twino.Protocols.WebSocket
         /// </summary>
         public async Task Ready(ITwinoServer server, WsServerSocket client)
         {
-            await Task.CompletedTask;
+            if (_readyHandler != null)
+                await _readyHandler(client);
         }
 
         /// <summary>

--- a/src/Twino.Protocols.WebSocket/Twino.Protocols.WebSocket.csproj
+++ b/src/Twino.Protocols.WebSocket/Twino.Protocols.WebSocket.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Title>Twino.Protocols.WebSocket</Title>
     <Product>Twino.Protocols.WebSocket</Product>
     <Description>WebSocket Protocol library and server extension for Twino Server</Description>
     <PackageTags>twino,tcp,server,http,websocket,protocol,ws</PackageTags>
-    <AssemblyVersion>2.7.18</AssemblyVersion>
-    <FileVersion>2.7.18</FileVersion>
-    <PackageVersion>2.7.18</PackageVersion>
+    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <FileVersion>2.8.0</FileVersion>
+    <PackageVersion>2.8.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
     <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.Protocols.WebSocket/WebSocketExtensions.cs
+++ b/src/Twino.Protocols.WebSocket/WebSocketExtensions.cs
@@ -66,7 +66,32 @@ namespace Twino.Protocols.WebSocket
                                                  WebSocketMessageRecievedHandler messageAction)
         {
             return UseWebSockets(server,
-                                 new MethodWebSocketConnectionHandler(connectedAction, messageAction),
+                                 new MethodWebSocketConnectionHandler(connectedAction, null, messageAction),
+                                 HttpOptions.CreateDefault());
+        }
+
+        /// <summary>
+        /// Uses WebSocket Protocol and accepts HTTP connections which comes with "Upgrade: websocket" header data
+        /// </summary>
+        public static ITwinoServer UseWebSockets(this ITwinoServer server,
+                                                 WebSocketConnectedHandler connectedAction,
+                                                 WebSocketReadyHandler readyAction,
+                                                 WebSocketMessageRecievedHandler messageAction)
+        {
+            return UseWebSockets(server,
+                                 new MethodWebSocketConnectionHandler(connectedAction, readyAction, messageAction),
+                                 HttpOptions.CreateDefault());
+        }
+
+        /// <summary>
+        /// Uses WebSocket Protocol and accepts HTTP connections which comes with "Upgrade: websocket" header data
+        /// </summary>
+        public static ITwinoServer UseWebSockets(this ITwinoServer server,
+                                                 WebSocketReadyHandler readyAction,
+                                                 WebSocketMessageRecievedHandler messageAction)
+        {
+            return UseWebSockets(server,
+                                 new MethodWebSocketConnectionHandler(null, readyAction, messageAction),
                                  HttpOptions.CreateDefault());
         }
     }

--- a/src/Twino.SerializableModel/Twino.SerializableModel.csproj
+++ b/src/Twino.SerializableModel/Twino.SerializableModel.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Title>Twino.SerializableModel</Title>
     <Product>Twino.SerializableModel</Product>
     <Description>Twino Serializable Model library for object based communication with text-based protocols</Description>
     <PackageTags>twino,tcp,server,http,websocket,serilizable,model</PackageTags>
-    <AssemblyVersion>2.7.18</AssemblyVersion>
-    <FileVersion>2.7.18</FileVersion>
-    <PackageVersion>2.7.18</PackageVersion>
+    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <FileVersion>2.8.0</FileVersion>
+    <PackageVersion>2.8.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
     <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>

--- a/src/Twino.Server/Twino.Server.csproj
+++ b/src/Twino.Server/Twino.Server.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <Title>Twino.Server</Title>
         <Product>Twino.Server</Product>
         <Description>Twino TCP Socket Server</Description>
         <PackageTags>twino,tcp,socket,server,http,websocket,tmq,mq</PackageTags>
-        <AssemblyVersion>2.7.18</AssemblyVersion>
-        <FileVersion>2.7.18</FileVersion>
-        <PackageVersion>2.7.18</PackageVersion>
+        <AssemblyVersion>2.8.0</AssemblyVersion>
+        <FileVersion>2.8.0</FileVersion>
+        <PackageVersion>2.8.0</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/mhelvacikoylu/twino</PackageProjectUrl>


### PR DESCRIPTION
**.NET Core 3.0 support is ending on 3rd Mar 2020.**

Twino Framework .NET Core version will be **3.1** until **2.8.0**. Next Twino Framework versions may be even or odd all new versions will be .NET Core 3.1. There wont't be any other .NET Core versions in future.

Latest .NET Core **3.0** supported version is **2.7.18**
Latest .NET Core **2.2** supported version is **2.5.3**